### PR TITLE
Add an alternate contact to vendor schema

### DIFF
--- a/src/schemas/Vendor.json
+++ b/src/schemas/Vendor.json
@@ -70,6 +70,31 @@
           "description": "Main physical/mailing address of the vendor.",
           "type": "string"
         },
+        "mainContactTitle": {
+          "description": "The title of the vendor's main point of contact. For example, 'Manager of Operations'.",
+          "type": "string"
+        },
+        "alternateContactName": {
+          "description": "The vendor's alternate/secondary point of contact person.",
+          "type": "string"
+        },
+        "alternateContactEmail": {
+          "description": "Email of the vendor's alternate/secondary point of contact person.",
+          "type": "string",
+          "format": "email"
+        },
+        "alternateContactPhone": {
+          "description": "Phone number of the vendor's alternate/secondary point of contact person.",
+          "type": "string"
+        },
+        "alternateContactAddress": {
+          "description": "Alternate/secondary physical/mailing address of the vendor.",
+          "type": "string"
+        },
+        "alternateContactTitle": {
+          "description": "The title of the vendor's alternate/secondary point of contact. For example, 'CISO'.",
+          "type": "string"
+        },
         "admins": {
           "description": "List of admin users to the vendor account, if applicable. If this vendor account is integrated directly to JupiterOne and its data is ingested, the admin users should be already mapped as User entities.",
           "type": "array",
@@ -122,15 +147,8 @@
           "format": "uri"
         }
       },
-      "required": [
-        "category"
-      ],
-      "excludes": [
-        "status",
-        "public",
-        "temporary",
-        "expiresOn"
-      ]
+      "required": ["category"],
+      "excludes": ["status", "public", "temporary", "expiresOn"]
     }
   ]
 }


### PR DESCRIPTION
When dealing with vendors, it's helpful to have two points of contact -- a main for current and routine communication, and an alternate for when things go sideways (maybe main is on vacation; maybe main lost their job, or died).

This PR adds an alternate contact to the vendor schema, allowing for the inclusion of this additional contact information. Also it adds a title to the main contact, to illuminate potential organizational relationships between the contacts -- for example, is the alternate an assistant to the main, or a superior, or a subordinate (which may be useful in guiding communication).

Will do an `npm version patch` once approvals gained on this code.