### PR TITLE
Add missing relationship classes, update docs

### DIFF
--- a/src/RelationshipClass.ts
+++ b/src/RelationshipClass.ts
@@ -1,10 +1,36 @@
+/**
+ * Standardized values for relationship `_class`.
+ */
 export enum RelationshipClass {
   ALLOWS = 'ALLOWS',
   ASSIGNED = 'ASSIGNED',
   CONNECTS = 'CONNECTS',
   CONTAINS = 'CONTAINS',
+
+  /**
+   * A relationship between a User and any Entity.
+   */
+  CREATED = 'CREATED',
+
+  /**
+   * A relationship between a CodeRepo and Function.
+   */
+  DEFINES = 'DEFINES',
+  
   DEPLOYED = 'DEPLOYED',
+
+  /**
+   * A relationship between a {Vulnerability, Finding} and Weakness.
+   */
+  EXPLOITS = 'EXPLOITS',
+
   EXTENDS = 'EXTENDS',
+
+  /**
+   * A relationship between any Entity and {Finding, Incident}.
+   */
+  GENERATED = 'GENERATED',
+
   HAS = 'HAS',
   IDENTIFIED = 'IDENTIFIED',
   IMPLEMENTS = 'IMPLEMENTS',
@@ -19,5 +45,11 @@ export enum RelationshipClass {
   PROVIDES = 'PROVIDES',
   TRIGGERS = 'TRIGGERS',
   TRUSTS = 'TRUSTS',
+
+  /**
+   * A relationship between a User and any Entity.
+   */
+  UPDATED = 'UPDATED',
+
   USES = 'USES',
 };

--- a/src/schemas/GraphObject.json
+++ b/src/schemas/GraphObject.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "#GraphObject",
-  "description": "Standard metadata properties of a graph object maintained by the system. These are visible to users but may not be directly modified.",
+  "description": "Standard metadata properties of a graph object, maintained by the system. These are visible to users but may not be directly modified.",
   "type": "object",
   "propertyNames": {
     "pattern": "^(_|tag\\.)?[A-Za-z0-9. -]+$"

--- a/src/schemas/GraphObject.json
+++ b/src/schemas/GraphObject.json
@@ -1,19 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "#GraphObject",
-  "description": "The standard metadata properties of a given entity/relationship. These properties are system generated (e.g. set by an integration).  They are viewable in the UI but not directly editable by a user.",
+  "description": "Standard metadata properties of a graph object maintained by the system. These are visible to users but may not be directly modified.",
   "type": "object",
   "propertyNames": {
     "pattern": "^(_|tag\\.)?[A-Za-z0-9. -]+$"
   },
   "properties": {
     "_key": {
-      "description": "A unique identifier of an entity/relationship within the scope of a single integration instance. For example, for a Bitbucket repo, this _id will be the GUID of the repo as assigned by Bitbucket. For an IAM Role, the _id will be the ARN of the role.",
+      "description": "An identifier unique within the scope containing the object. For example, for a Bitbucket repo, this will be the GUID of the repo as assigned by Bitbucket. For an IAM Role, this will be the ARN of the role.",
       "type": "string",
       "minLength": 10
     },
     "_class": {
-      "description": "Used to create an abstract security data model. For example, a EC2 instance will have '_class':'Host'. An integration can supply one or more classes which can be used to indicate if a particular entity/relationship conforms to one or more standard classifications. This property is similar to _type except that _class refers to a type that has been standardized while _type is an entity type that only has to be unique in the scope of the provider. It is possible that an entity/relationship has a _type value but no _class value in cases where there is no standard classification for a given entity/relationship.",
+      "description": "One or more classes conforming to a standard, abstract security data model. For example, an EC2 instance will have '_class':'Host'.",
       "oneOf": [
         {
           "type": "string",
@@ -30,7 +30,7 @@
       ]
     },
     "_type": {
-      "description": "Describes the type of entity/relationship as identified by the data source (often the integration or sometimes manual user input). The _class property is similar to _type but _class refers to a categorization that has been standardized and it is not unique to a single data integration.",
+      "description": "The type of object, typically reflecting the vendor and resource type. For example, 'aws_iam_user'. In some cases, a system knows about a type of entity that other systems know about, such as 'user_endpoint'.",
       "type": "string",
       "minLength": 5
     }


### PR DESCRIPTION
A step toward https://github.com/JupiterOne/sdk/issues/285, though primarily capturing things recently used that we have agreed should be included. Also clarifying the meaning of `_class` and `_type`.