### PR TITLE
Add ns domain record AND version 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.10.0 - 2020-09-09
+
+### Added
+
+- Added `NS` as valid `DomainRecord`.`type` value
+
 ## 0.9.0 - 2020-08-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/data-model",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/schemas/DomainRecord.json
+++ b/src/schemas/DomainRecord.json
@@ -24,6 +24,7 @@
             "LOC",
             "MX",
             "NX",
+            "NS",
             "NAPTR",
             "PTR",
             "SMIMEA",


### PR DESCRIPTION
The Azure cloud provider allows users to create Record Sets with the following `type`s. Some records failed validation since our data model did not include `NS` as a valid record type.

<img width="320" alt="Screen Shot 2020-09-09 at 5 03 12 PM" src="https://user-images.githubusercontent.com/15333061/92654784-59a64b80-f2be-11ea-97d0-f90b167660e2.png">


