### PR TITLE
Entity.id: string | string[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,8 @@ and this project adheres to
 
 ### Changed
 
-- `Entity.id` allows `string | number | (string | number)[]`. Though typically
-  it is best that Array properties are homogenious, `id` is a case where
-  different providers identify an Entity with different values, some using a
-  `string`, others a `number`. This change will allow `id` to capture the value
-  from each provider that tracks the Entity.
+- `Entity.id` allows `string | string[]`. This change will allow `id` to capture
+  values from each provider that tracks an Entity.
 
 ## 0.10.0 - 2020-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,33 @@ and this project adheres to
 
 ### Added
 
-- Added `createdBy`, `updatedBy`, `deletedBy`, `discoveredBy` to `Entity` schema
-- Added `RelationshipClass.SCANS` constant
+- Added `createdBy`, `updatedBy`, `deletedBy`, `discoveredBy` to `Entity`
+  schema.
+- Added `RelationshipClass.SCANS` constant.
+
+### Changed
+
+- `Entity.id` allows `string | number | (string | number)[]`. Though typically
+  it is best that Array properties are homogenious, `id` is a case where
+  different providers identify an Entity with different values, some using a
+  `string`, others a `number`. This change will allow `id` to capture the value
+  from each provider that tracks the Entity.
 
 ## 0.10.0 - 2020-09-09
 
 ### Added
 
-- Added `NS` as valid `DomainRecord`.`type` value
+- Added `NS` as valid `DomainRecord`.`type` value.
 
 ## 0.9.0 - 2020-08-26
 
 ### Added
 
-- Added `DENIES` relationship class
+- Added `DENIES` relationship class.
 
 ## 0.8.1 - 2020-08-20
 
 ### Changed
 
 - [#30](https://github.com/JupiterOne/data-model/issues/30) - Remove requirement
-  for `hostname` property in `Host` schema
+  for `hostname` property in `Host` schema.

--- a/src/schemas/Entity.json
+++ b/src/schemas/Entity.json
@@ -9,10 +9,10 @@
       "properties": {
         "id": {
           "description": "Identifiers of this entity assigned by the providers. Values are expected to be unique within the provider scope.",
-          "type": ["string", "number", "array"],
+          "type": ["string", "array"],
           "items": [
             {
-              "type": ["string", "number"]
+              "type": "string"
             }
           ]
         },

--- a/src/schemas/Entity.json
+++ b/src/schemas/Entity.json
@@ -8,8 +8,13 @@
     {
       "properties": {
         "id": {
-          "description": "Identifier of this entity assigned by the provider. Unique within the provider scope.",
-          "type": "string"
+          "description": "Identifiers of this entity assigned by the providers. Values are expected to be unique within the provider scope.",
+          "type": ["string", "number", "array"],
+          "items": [
+            {
+              "type": ["string", "number"]
+            }
+          ]
         },
         "name": {
           "description": "Name of this entity",

--- a/src/validateEntityWithSchema.test.ts
+++ b/src/validateEntityWithSchema.test.ts
@@ -1,23 +1,78 @@
 import { validateEntityWithSchema } from './validateEntityWithSchema';
 
 test('throws error if schema does not exist', () => {
-  expect(
-    () => validateEntityWithSchema({ _class: ["ChimkenNumget"] })
-  ).toThrow("Could not find schema for class ChimkenNumget!");
+  expect(() => validateEntityWithSchema({ _class: ['ChimkenNumget'] })).toThrow(
+    'Could not find schema for class ChimkenNumget!',
+  );
 });
 
 test('throws error if entity fails to validate', () => {
-  expect(
-    () => validateEntityWithSchema({ _class: ["Account"] })
-  ).toThrow("Entity fails to validate as class 'Account'");
+  expect(() => validateEntityWithSchema({ _class: ['Account'] })).toThrow(
+    "Entity fails to validate as class 'Account'",
+  );
 });
 
 test('does not throw if entity successfully validates', () => {
-  expect(
-    () => validateEntityWithSchema({
-      _class: ["GraphObject"],
-      _key: "my_testing_key",
-      _type: "my_testing_type",
-    } as any)
+  expect(() =>
+    validateEntityWithSchema({
+      _class: ['GraphObject'],
+      _key: 'my_testing_key',
+      _type: 'my_testing_type',
+    } as any),
   ).not.toThrow();
+});
+
+describe('Entity', () => {
+  const requiredProperties = {
+    _class: ['Entity'],
+    _key: 'my_testing_key',
+    _type: 'my_testing_type',
+    name: 'John',
+    displayName: 'Wick',
+  };
+
+  test('allows string as id', () => {
+    expect(() =>
+      validateEntityWithSchema({
+        ...requiredProperties,
+        id: 'sumpinsumpin',
+      } as any),
+    ).not.toThrow();
+  });
+
+  test('allows string[] as id', () => {
+    expect(() =>
+      validateEntityWithSchema({
+        ...requiredProperties,
+        id: ['sumpinsumpin', 'nuttinnuttin'],
+      } as any),
+    ).not.toThrow();
+  });
+
+  test('allows number as id', () => {
+    expect(() =>
+      validateEntityWithSchema({
+        ...requiredProperties,
+        id: 123,
+      } as any),
+    ).not.toThrow();
+  });
+
+  test('allows number[] as id', () => {
+    expect(() =>
+      validateEntityWithSchema({
+        ...requiredProperties,
+        id: [123, 456],
+      } as any),
+    ).not.toThrow();
+  });
+
+  test('allows (string | number)[] as id', () => {
+    expect(() =>
+      validateEntityWithSchema({
+        ...requiredProperties,
+        id: ['gogogo', 456],
+      } as any),
+    ).not.toThrow();
+  });
 });

--- a/src/validateEntityWithSchema.test.ts
+++ b/src/validateEntityWithSchema.test.ts
@@ -48,31 +48,4 @@ describe('Entity', () => {
       } as any),
     ).not.toThrow();
   });
-
-  test('allows number as id', () => {
-    expect(() =>
-      validateEntityWithSchema({
-        ...requiredProperties,
-        id: 123,
-      } as any),
-    ).not.toThrow();
-  });
-
-  test('allows number[] as id', () => {
-    expect(() =>
-      validateEntityWithSchema({
-        ...requiredProperties,
-        id: [123, 456],
-      } as any),
-    ).not.toThrow();
-  });
-
-  test('allows (string | number)[] as id', () => {
-    expect(() =>
-      validateEntityWithSchema({
-        ...requiredProperties,
-        id: ['gogogo', 456],
-      } as any),
-    ).not.toThrow();
-  });
 });


### PR DESCRIPTION
See discussion in https://github.com/JupiterOne/graph-qualys/pull/23#discussion_r497521472.

Also helpful, @charlieduong94 confirmed this is okay to do, FTR:

```
Adam Williams  11:07 AM
Yo! Is it okay for an entity property to be (string | number)[] , or should we avoid that? I'm working to allow Entity.id: string | string[], but wondered if we could allow number as well, since in Qualys the id is a number.

Charlie Duong  11:08 AM
Yeah, that's fine. We handle mixed types in elasticsearch and neptune has not issues with it. There are already places where mixed types occur.

Charlie Duong  11:10 AM
imo it's better to not mix types because neptune doesn't handle sorting that data well, but the upcoming changes to j1ql + the graph, we should be able to handle mixed types better

Adam Williams  11:11 AM
The SDK already enforces id: string.
11:11
I guess the problem may come when there is comparisons in the query...
11:12
Such as, find Entity with id=1234, folks are going to have to know to do find Entity with id='1234'?

Charlie Duong  11:13 AM
probs not.... it may be better in this situation (specifically for ids) to just go ahead with allowing the "natural" id to be whatever comes from the provider. So in this case allow for number ids from Qualys.
11:13
Less surprising to the user. Also it doesn't seem like id sorting would be really be done.
```