### PR TITLE
Allow array type for publicIpAddress and privateIpAddress in HOST

### DIFF
--- a/src/schemas/Host.json
+++ b/src/schemas/Host.json
@@ -31,14 +31,26 @@
           "format": "hostname"
         },
         "publicIpAddress": {
-          "description": "The public IP address",
-          "type": "string",
-          "format": "ipv4"
+          "description": "The public IP address or addresses",
+          "type": ["string", "array"],
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "format": "ipv4",
+          "uniqueItems": true
         },
         "privateIpAddress": {
-          "description": "The private IP address",
-          "type": "string",
-          "format": "ipv4"
+          "description": "The private IP address or addresses",
+          "type": ["string", "array"],
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "format": "ipv4",
+          "uniqueItems": true
         },
         "ipAddresses": {
           "description": "A listing of all IPv4 addresses associated with this Host",


### PR DESCRIPTION
Google Cloud compute instances can have multiple public/private IP
addresses all of which should be picked up in mappings.