### PR TITLE
Allow `null` value for Network class CIDR property

### DIFF
--- a/src/schemas/Network.json
+++ b/src/schemas/Network.json
@@ -27,7 +27,7 @@
         },
         "CIDR": {
           "description": "The IPv4 network CIDR block (e.g. 0.0.0.0/0)",
-          "type": "string",
+          "type": ["string", "null"],
           "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$"
         },
         "CIDRv6": {


### PR DESCRIPTION
Google Cloud networks do not have IP addresses on their own. I
think we should still force integrations to bypass this field with
a `null` value for now.