### PR TITLE
Finding {severity, numericSeverity}, examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `numericSeverity` as a required property to `Finding` entity
+
+### Changed
+
+- `Finding.severity` provides `examples`
+
 ## 0.14.1 2020-10-07
 
 ### Updated

--- a/src/schemas/Finding.json
+++ b/src/schemas/Finding.json
@@ -22,8 +22,21 @@
           "type": "string"
         },
         "severity": {
-          "description": "Severity rating based on impact and exploitability. Can be a string such as 'critical', 'high', 'medium', 'low', 'info'.  Or an integer usually between 0-5.",
-          "type": "string"
+          "description": "Severity rating based on impact and exploitability.",
+          "type": "string",
+          "examples": [
+            "none",
+            "informational",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ]
+        },
+        "numericSeverity": {
+          "description": "Severity rating based on impact and exploitability.",
+          "type": "number",
+          "examples": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         },
         "priority": {
           "description": "Priority level mapping to Severity rating. Can be a string such as 'critical', 'high', 'medium', 'low', 'info'.  Or an integer usually between 0-5.",
@@ -103,7 +116,7 @@
           }
         }
       },
-      "required": ["category", "severity", "open"]
+      "required": ["category", "severity", "numericSeverity", "open"]
     }
   ]
 }


### PR DESCRIPTION
`severity` was already required, added examples that demonstrate the latest preferences. Added `numericSeverty` as new, required property with examples suggesting values should be 1-10.

![Screen Shot 2020-10-09 at 11 05 47 AM](https://user-images.githubusercontent.com/2571/95599717-6c2bb600-0a1f-11eb-9ea4-9d661b005ae6.png)
