### PR TITLE
Add Contact entity schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.16.0
+
+### Added
+
+- Added `Contact` entity schema
+
 ## 0.15.0
 
 ### Added

--- a/src/IntegrationSchema.ts
+++ b/src/IntegrationSchema.ts
@@ -162,6 +162,8 @@ import Control from "./schemas/Control.json";
 IntegrationSchema.addSchema(Control);
 import Container from "./schemas/Container.json";
 IntegrationSchema.addSchema(Container);
+import Contact from "./schemas/Contact.json";
+IntegrationSchema.addSchema(Contact);
 import Configuration from "./schemas/Configuration.json";
 IntegrationSchema.addSchema(Configuration);
 import CodeReview from "./schemas/CodeReview.json";

--- a/src/schemas/Contact.json
+++ b/src/schemas/Contact.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "#User",
+  "description": "Contact information details. For example, an emergency contact.",
+  "type": "object",
+  "allOf": [
+    { "$ref": "#Entity" },
+    {
+      "properties": {
+        "firstName": {
+          "description": "The person's official first name in the system (such as HR database)",
+          "type": "string"
+        },
+        "lastName": {
+          "description": "The person's official last name in the system (such as HR database)",
+          "type": "string"
+        },
+        "middleName": {
+          "description": "The person's official middle name in the system (such as HR database)",
+          "type": "string"
+        },
+        "phone": {
+          "description": "The contact's phone numbers; the first one in the array is the primary contact number.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "email": {
+          "description": "The email address associated with the contact",
+          "type": "string",
+          "format": "email"
+        },
+        "address": {
+          "description": "The contact's physical contact address",
+          "type": "string"
+        }
+      },
+      "required": []
+    }
+  ]
+}


### PR DESCRIPTION
Example is an Azure Security Contact, which is not necessarily a `Person` or a `User`. See: https://docs.microsoft.com/en-us/rest/api/securitycenter/securitycontacts/create

We could also use this to ingest contact directories (e.g. phone contacts)