### PR TITLE
Introduce a ConfigurableHostAgent for use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `ConfigurableHostAgent` entity
+
 ## 0.18.0 - 2021-03-16
 
 ### Added

--- a/src/schemas/ConfigurableHostAgent.json
+++ b/src/schemas/ConfigurableHostAgent.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "#ConfigurableHostAgent",
+  "description": "A software agent that runs on a host/endpoint whose governance functionality is determined by attached Configurations and Policies.",
+
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#Entity"
+    }
+  ]
+}


### PR DESCRIPTION
### Purpose
There is a limitation with J1QL where there is no way to remove values from your returned tree based on information you find out later in your traversal. For instance, in the endpoint managed question "Is there malware protection for all endpoints?", there are 2 different structures a HostAgent can have to provide malware protection for an endpoint. 

1.  A HostAgent with `function=anti-malware` can be related directly to the Host
2. A Configuration with `function=anti-malware` can be related to a HostAgent which then is related to the Host

This question can be easily answered for the affirmative, but when attempting the negative case, the problem becomes clear.  There is no way to write a question that can not produce false positives while using Classes. If you write a question to solve for the first point
```
find (user_endpoint|workstation|laptop|desktop|computer|smartphone|tablet)
     that !(PROTECTS|MANAGES|ASSIGNED|MONITORS) HostAgent with function='anti-malware'
```
You get false positives for the second point. And when you solve for the second point:
```
          Find (user_endpoint|workstation|laptop|desktop|computer|smartphone|tablet) as device
            that (PROTECTS|MANAGES|ASSIGNED|MONITORS) HostAgent as agent
            /* First filter results to those that do not have anti-malware Policies
            that !ASSIGNED (ControlPolicy|Configuration) with function='anti-malware' as malwareConfig
            /* Then filter the remaining results to HostAgents with anti-malware protection */
            WHERE  agent.function!='anti-malware'
```
You get false positives for the first point.

You can get pretty fancy to be able to handle almost all cases (example in comments), but even still you just can't handle all edge cases.

### Possible Solutions

1. This PR. If I use `ConfigurableHostAgent` as well as `HostAgent`, the problem can be solved with:
```
          find (user_endpoint|workstation|laptop|desktop|computer|smartphone|tablet) as device
            (that (PROTECTS|MANAGES|ASSIGNED|MONITORS) ConfigurableHostAgent with function!='anti-malware')?
            that !(PROTECTS|MANAGES|ASSIGNED|MONITORS) (ControlPolicy|Configuration|HostAgent) with function='anti-malware' or _class='ConfigurableHostAgent' as agentOrConfig
            return device.displayName, device.owner, device.id, device.users
```
Which works but is still kind of a hack imho

2. Add branching paths or recursive relationships or result manipulations to the query language. Really just anything give J1QL the ability to solve this example case. The interface could be something like:
```
find (user_endpoint|workstation|laptop|desktop|computer|smartphone|tablet) as device
            THAT EITHER
                       !(PROTECTS|MANAGES|ASSIGNED|MONITORS) HostAgent) with function='anti-malware'
           OR 
                       (PROTECTS|MANAGES|ASSIGNED|MONITORS) HostAgent) with function!='anti-malware'
                       THAT !ASSIGNED (ControlPolicy|Configuration) with function='anti-malware'
           RETURN device.displayName
```
EITHER ... OR ... is the new functionality here.

Or maybe a way to indicate that something relates recursively (risky but nice):
```
find (user_endpoint|workstation|laptop|desktop|computer|smartphone|tablet) as device
  >>> that !RECURSIVE RELATES TO (ControlPolicy|Configuration|HostAgent) with function='anti-malware'
```

Or perhaps just add a way to remove data that is in the active branch like:
```
find (user_endpoint|workstation|laptop|desktop|computer|smartphone|tablet) as device
            (that (PROTECTS|MANAGES|ASSIGNED|MONITORS) HostAgent with function!='anti-malware' as agentOrNull)?
            that !(PROTECTS|MANAGES|ASSIGNED|MONITORS) (ControlPolicy|Configuration|HostAgent) with function='anti-malware' as agentOrConfig
    >>> REMOVE device WHERE agentOrConfig._key!=undefined
            return device.displayName
```
All of these I believe would work for the example.

3. Use types instead of classes in managed questions for this traversal.
This pollutes managed questions with details specific to integrations, which is not a pattern I would like to follow, but it does solve this problem in a pinch.

4. (Edit) Add a `configurable=true` key to the host agent to key off of.
I just thought of this this morning and this would also solve the problem and it might just be the best solution.
```
          find (user_endpoint|workstation|laptop|desktop|computer|smartphone|tablet) as device
            (that (PROTECTS|MANAGES|ASSIGNED|MONITORS) HostAgent with function!='anti-malware' and configurable=true)?
            that !(PROTECTS|MANAGES|ASSIGNED|MONITORS) (ControlPolicy|Configuration|HostAgent) with function='anti-malware' or configurable=true as agentOrConfig
            return device.displayName, device.owner, device.id, device.users
```