### PR TITLE
Fix #82 - Add retentionPeriod property to DataStore class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.21.0 - 2021-04-28
+
+### Added
+
+- Fix [#82](https://github.com/JupiterOne/data-model/issues/82) - Add
+  `retentionPeriod` property to `DataStore` class that represents the number of
+  days that data will be retained for.
+
 ## 0.20.1 - 2021-04-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 ### Added
 
 - Fix [#82](https://github.com/JupiterOne/data-model/issues/82) - Add
-  `retentionPeriod` property to `DataStore` class that represents the number of
+  `retentionPeriodDays` property to `DataStore` class that represents the number of
   days that data will be retained for.
 
 ## 0.20.1 - 2021-04-15

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/data-model",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/schemas/DataStore.json
+++ b/src/schemas/DataStore.json
@@ -37,7 +37,7 @@
           "description": "Indicates if the data store is data backup has been configured/enabled.",
           "type": "boolean"
         },
-        "retentionPeriod": {
+        "retentionPeriodDays": {
           "description": "The number of days for which data is retained",
           "type": "number"
         }

--- a/src/schemas/DataStore.json
+++ b/src/schemas/DataStore.json
@@ -36,6 +36,10 @@
         "hasBackup": {
           "description": "Indicates if the data store is data backup has been configured/enabled.",
           "type": "boolean"
+        },
+        "retentionPeriod": {
+          "description": "The number of days for which data is retained",
+          "type": "number"
         }
       },
       "required": ["classification", "encrypted"]


### PR DESCRIPTION
This was a request from @erkangz.

It makes me wonder if we should suffix these types of properties with the actual unit of time for clarity (e.g. `retentionPeriodDays`). It is not immediately clear that this property by name should be in days or some other unit without actually reviewing the data model. `number` won't prevent "invalid" values (e.g. timestamp in milliseconds) from being assigned to this property.

Thoughts?