### PR TITLE
Add reported relationship class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.28.0 - 2021-06-10
+
+### Added
+
+- Added `REPORTED` to the `RelationshipClass` enum
+
 ## 0.27.0 - 2021-06-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/data-model",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/RelationshipClass.ts
+++ b/src/RelationshipClass.ts
@@ -140,6 +140,7 @@ export enum RelationshipClass {
   RESTRICTS = 'RESTRICTS',
 
   REVIEWED = 'REVIEWED',
+  REPORTED = 'REPORTED',
 
   /**
    * A relationships indicating an Entity performs some kind of scan on another Entity.


### PR DESCRIPTION
The Jira integration uses this relationship class and we need to add it here to move the Jira integration to the new SDK.