### PR TITLE
CORE-1370 - add Question class

### DIFF
--- a/src/IntegrationSchema.ts
+++ b/src/IntegrationSchema.ts
@@ -139,6 +139,10 @@ import RecordJson from './schemas/Record.json';
 export const Record = RecordJson;
 IntegrationSchema.addSchema(Record);
 
+import QuestionJson from './schemas/Question.json';
+export const Question = QuestionJson;
+IntegrationSchema.addSchema(Question);
+
 import QueueJson from './schemas/Queue.json';
 export const Queue = QueueJson;
 IntegrationSchema.addSchema(Queue);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -197,3 +197,22 @@ describe('Problem', () => {
     expect(validateProblem(entityWithoutFindingProperties)).toBe(false);
   });
 });
+
+describe('Question', () => {
+  test('should require queries to be provided', () => {
+    const validateQuestion = IntegrationSchema.getSchema('#Question')!;
+    const entity = {
+      _type: 'some-type-of-question',
+      _class: 'Question',
+      _key: 'some-key-unique',
+      name: 'Name of Question',
+      displayName: 'Name of Question',
+    };
+
+    expect(validateQuestion(entity)).toBe(false);
+    expect(validateQuestion({
+      ...entity,
+      queries: []
+    })).toBe(true);
+  });
+});

--- a/src/schemas/Question.json
+++ b/src/schemas/Question.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "#Question",
+  "description": "An object that represents an inquiry, usually around some matter of uncertainty or difficulty.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#Entity"
+    },
+    {
+      "properties": {
+        "queries": {
+          "description": "A request for information that contributes to answering a question.",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Questions are going to start becoming first class citizens within the j1 graph. The plan is to have have relationships to compliance items and, in the near future, Alerts thanks to @plfx. Atm, I'm keeping it simple with just the requirement that `queries` match an expected shape. 

Aside from J1 Questions, the other concept that could adopt this class would be Security Questionnaire items, which would likely make use of a yet to be enforced `answer` property.