### PR TITLE
Add domainName to the User and Person schemas

### DIFF
--- a/src/schemas/Person.json
+++ b/src/schemas/Person.json
@@ -29,6 +29,14 @@
             "format": "email"
           }
         },
+        "domainName": {
+          "description": "The domain portion of the email addresses associated with the user account.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "string"
+          }
+        },
         "title": {
           "description": "The person's role or title within an organization",
           "type": "string"

--- a/src/schemas/User.json
+++ b/src/schemas/User.json
@@ -16,6 +16,11 @@
           "type": "string",
           "format": "email"
         },
+        "domainName": {
+          "description": "The domain portion of the email address associated with the user account.",
+          "type": "string",
+          "format": "string"
+        },
         "shortLoginId": {
           "description": "The shortened login Id. For example, if the username is the full email address (first.last@company.com), the shortLoginId would be the part before @ (first.last).",
           "type": "string"


### PR DESCRIPTION
The graph-google-cloud integration's access can have a value allowing all Google users that have an email with a certain domain name (google_domains) to have access to something. In order to make reverse access analysis possible, ie: going from a User record and traversing the graph to all that they have access to, we should have a relationship between a User and the google_domain that relates to their email, and the only way to make that relationship is to add a `domainName` property on user records as there is no URL parser ability for global mapping rules.