### PR TITLE
Add RelationshipClass.HOSTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Added `RelationshipClass.HOSTS`
+
 ## 0.40.0 - 2021-10-25
 
 - Added `RelationshipClass.VIOLATES`

--- a/src/IntegrationSchema.ts
+++ b/src/IntegrationSchema.ts
@@ -422,3 +422,4 @@ IntegrationSchema.addSchema(AccessPolicy);
 import AccessKeyJson from './schemas/AccessKey.json';
 export const AccessKey = AccessKeyJson;
 IntegrationSchema.addSchema(AccessKey);
+

--- a/src/RelationshipClass.ts
+++ b/src/RelationshipClass.ts
@@ -102,6 +102,11 @@ export enum RelationshipClass {
   HAS = 'HAS',
 
   /**
+   * A relationship between a Vendor and an Account
+   */
+  HOSTS = 'HOSTS',
+
+  /**
    * A relationship indicating an Entity identified another Entity.
    *
    * Examples:


### PR DESCRIPTION
Seems we didn't support `HOSTS` in our data model.

:gulp:

https://support.jupiterone.io/hc/en-us/articles/360041392094-Entity-Relationship-Mapping-Integration-Rules