### PR TITLE
Removed the format for the emailDomain which throws a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.42.1 - 2022-01-04
+
+### Fixed
+
+- Warning was being thrown for usage of `format: string` for emailDomain property. Removed
+  the format to silience the warning.
+
 ## 0.42.0 - 2021-12-15
 
 - Added `RelationshipClass.HOSTS`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/data-model",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/schemas/Person.json
+++ b/src/schemas/Person.json
@@ -33,8 +33,7 @@
           "description": "The domain portion of the email addresses associated with the user account.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "string"
+            "type": "string"          
           }
         },
         "title": {

--- a/src/schemas/User.json
+++ b/src/schemas/User.json
@@ -20,8 +20,7 @@
           "description": "The domain portion of the email addresses associated with the user account.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "string"
+            "type": "string"
           }
         },
         "shortLoginId": {


### PR DESCRIPTION
<img width="857" alt="Screen Shot 2022-01-04 at 4 24 16 PM" src="https://user-images.githubusercontent.com/11580747/148125776-7b58f4d1-3431-4215-b326-b1fafc8a50f9.png">
