### PR TITLE
Making required properties on Device Schema nullable.

### DIFF
--- a/src/schemas/Device.json
+++ b/src/schemas/Device.json
@@ -9,7 +9,7 @@
       "properties": {
         "category": {
           "description": "The device category",
-          "type": "string",
+          "type": ["string", "null"],
           "examples": [
             "server",
             "endpoint",
@@ -21,11 +21,11 @@
         },
         "make": {
           "description": "Same as hardwareVendor: The manufacturer or vendor of the device, e.g. Apple Inc., Generic",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "model": {
           "description": "Same as hardwareModel: The device hardware model, e.g. MacBookPro13,3",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "version": {
           "description": "Same as hardwareVersion: The device hardware version",
@@ -33,7 +33,7 @@
         },
         "serial": {
           "description": "Same as hardwareSerial: The device serial number",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hardwareVendor": {
           "description": "The manufacturer or vendor of the device, e.g. Apple Inc., Generic",


### PR DESCRIPTION
## Description

This PR makes the required `Device` properties, `category`, `make`, `model`, and `serial`,  null-able properties.

## Rationale

In `graph-rumble`, there are `rumble_asset` entities. These assets are all networked devices such as servers, desktops, phones, etc. These entities would be best classified as `Devices`. However, the response from Rumble API does not contain enough information to fill the required properties. Information about the `category`, `make`, and `model` are sometimes available, but `serial` could never be populated with the data from the response.

If a `rumble_asset` cannot use the `Device` schema, then the entity would be misclassified. By making required properties optionally null-able, the data model can encourage using common properties when available while retaining the flexibility to classify  entities correctly when not all information is available.

There are other ways of achieving the same goal, so any ideas or feedback is appreciated!

## Related Issues

Previous discussion on allowing all properties to be `null` during graph validation: https://github.com/JupiterOne/data-model/issues/13
Possibility of using data-model to generate types for typescript or any other typed language: https://github.com/JupiterOne/data-model/issues/12

## References
[graph-rumble repo](https://github.com/jupiterone/graph-rumble)
[rumble_asset pull request](https://github.com/JupiterOne/graph-rumble/pull/18)
[example Rumble asset response](https://app.swaggerhub.com/apis-docs/RumbleDiscovery/Rumble/2.10.0#/Export/exportAssetsJSON)
