### PR TITLE
Making `Vulnerability` required properties optionally nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
-- Allow `null` to be assigned to the following required `Vulnerability` properties
+- Allow `null` to be assigned to the following required `Vulnerability`
+  properties
+  - `category`
+  - `severity`
+  - `blocking`
+  - `open`
+  - `production`
+  - `public`
 
 ## 0.46.0 - 2022-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Allow `null` to be assigned to the following required `Vulnerability` properties
+
 ## 0.46.0 - 2022-03-25
 
 ### Added

--- a/src/schemas/Vulnerability.json
+++ b/src/schemas/Vulnerability.json
@@ -11,7 +11,7 @@
       "properties": {
         "category": {
           "description": "The category of the vulnerability finding",
-          "type": "string",
+          "type": ["string", "null"],
           "examples": [
             "application",
             "system",
@@ -25,7 +25,7 @@
         },
         "severity": {
           "description": "Severity rating based on impact and exploitability. Can be a string such as 'critical', 'high', 'medium', 'low', 'info'.  Or an integer usually between 0-5.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "priority": {
           "description": "Priority level mapping to Severity rating. Can be a string such as 'critical', 'high', 'medium', 'low', 'info'.  Or an integer usually between 0-5.",
@@ -60,20 +60,20 @@
         },
         "blocking": {
           "description": "Indicates whether this vulnerability finding is a blocking issue. If true, it should block a production deploy. Defaults to false.",
-          "type": "boolean",
+          "type": ["boolean","null"],
           "default": false
         },
         "open": {
           "description": "Indicates if this is an open vulnerability.",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "production": {
           "description": "Indicates if this vulnerability is in production.",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "public": {
           "description": "Indicates if this is a publicly disclosed vulnerability. If yes, this is usually a CVE and the 'webLink' should be set to 'https://nvd.nist.gov/vuln/detail/${CVE-Number}' or to a vendor URL. If not, it is most likely a custom application vulnerability.",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "validated": {
           "description": "Indicates if this Vulnerability finding has been validated by the security team.",


### PR DESCRIPTION
# Description

This PR makes `Vulnerability` required properties `category`, `blocking`, `public`, `severity`, `open`, and `production` optionally nullable.

The `Vulnerability` schema should see more use, but currently is only created indirectly through a mapped relationship target or suffers from something like the following in the `graph-rapid7` repo:
```ts
        // Response doesn't contain these attributes
        // but are needed for data model:
        blocking: false,
        open: false,
        production: false,
        public: true,
```