### PR TITLE
Updating build.yml workflow to Node 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
         os: [ubuntu-latest]
 
     steps:
@@ -35,13 +35,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12]
+        node: [14]
 
     steps:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Check out repo
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

This PR updates the `build.yml` workflow to use Node 14 as Node 12 support is expiring.