### PR TITLE
DEVICE-23 - Add `lastSeenOn` property to `Device` and `HostAgent`

### DIFF
--- a/external/resolvedSchemas.json
+++ b/external/resolvedSchemas.json
@@ -6362,6 +6362,11 @@
         ],
         "inherited": true
       },
+      "lastSeenOn": {
+        "description": "The timestamp (in milliseconds since epoch) when the device was last seen. For example, some devices that are managed by vendors, check-in with the vendor.",
+        "type": "number",
+        "format": "date-time"
+      },
       "location": {
         "description": "Site where this device is located.",
         "type": "string"
@@ -9814,6 +9819,11 @@
           { "type": "array", "items": { "type": "string" } }
         ],
         "inherited": true
+      },
+      "lastSeenOn": {
+        "description": "The timestamp (in milliseconds since epoch) when the host agent last checked-in with the vendor.",
+        "type": "number",
+        "format": "date-time"
       },
       "name": {
         "description": "Name of this entity",

--- a/src/schemas/Device.json
+++ b/src/schemas/Device.json
@@ -166,6 +166,11 @@
             "unknown",
             "other"
           ]
+        },
+        "lastSeenOn": {
+          "description": "The timestamp (in milliseconds since epoch) when the device was last seen. For example, some devices that are managed by vendors, check-in with the vendor.",
+          "type": "number",
+          "format": "date-time"
         }
       },
       "required": ["category", "make", "model", "serial", "deviceId"]

--- a/src/schemas/HostAgent.json
+++ b/src/schemas/HostAgent.json
@@ -30,6 +30,11 @@
               "other"
             ]
           }
+        },
+        "lastSeenOn": {
+          "description": "The timestamp (in milliseconds since epoch) when the host agent last checked-in with the vendor.",
+          "type": "number",
+          "format": "date-time"
         }
       },
       "required": ["function"]


### PR DESCRIPTION
> There is currently no property on the Device or HostAgent data models that represents that last time that a device checked in with its vendor. We need this to properly develop a view in the Device Management UI that indicates the last time that a device genuinely checked-in with each vendor. There is a clear distinction between the last time that a device checked-in with its vendor, the last time the integration was ran, and the last time the device properties were updated.
>
> The reason why its important for this property to be represented on Device and HostAgent is because not every Device is protected by a HostAgent.  Some vendors, like Jamf and Kandji do not have a host agent (software) running on them. Instead, they use Apple MDM (for example) to communicate with devices through Apple push notifications. [You can read more about that here](https://support.kandji.io/support/solutions/articles/72000560409-the-kandji-agent-and-mdm).

See: https://jptrone.slack.com/archives/C03DCN9102V/p1683808020844519