### PR TITLE
DEVICE-133 - Add lastSeenOn as a required property on both Devices and HostAgents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `lastSeenOn` as a required property on both Devices and HostAgents.
+
 ## 0.54.0 - 2023-03-01
 
 ### Changed

--- a/external/resolvedSchemas.json
+++ b/external/resolvedSchemas.json
@@ -6362,6 +6362,11 @@
         ],
         "inherited": true
       },
+      "lastSeenOn": {
+        "description": "The timestamp (in milliseconds since epoch) when the device either last checked in or was scanned.",
+        "type": ["number", "null"],
+        "format": "date-time"
+      },
       "location": {
         "description": "Site where this device is located.",
         "type": "string"

--- a/src/schemas/Device.json
+++ b/src/schemas/Device.json
@@ -149,6 +149,11 @@
           "description": "Screen lock timeout in seconds",
           "type": "number"
         },
+        "lastSeenOn": {
+          "description": "The timestamp (in milliseconds since epoch) when the device either last checked in or was scanned.",
+          "type": ["number", "null"],
+          "format": "date-time"
+        },
         "status": {
           "description": "Status label of this device",
           "type": "string",
@@ -168,7 +173,14 @@
           ]
         }
       },
-      "required": ["category", "make", "model", "serial", "deviceId"]
+      "required": [
+        "category",
+        "make",
+        "model",
+        "serial",
+        "deviceId",
+        "lastSeenOn"
+      ]
     }
   ]
 }

--- a/src/schemas/HostAgent.json
+++ b/src/schemas/HostAgent.json
@@ -32,7 +32,12 @@
           }
         }
       },
-      "required": ["function"]
+      "lastSeenOn": {
+        "description": "The timestamp (in milliseconds since epoch) when the device either last checked in or was scanned.",
+        "type": ["number", "null"],
+        "format": "date-time"
+      },
+      "required": ["function", "lastSeenOn"]
     }
   ]
 }


### PR DESCRIPTION
See: https://jptrone.slack.com/archives/C03DCN9102V/p1683808020844519

lastSeenOn is a necessary property for the Device Management page and is generally an important piece of information to know for security. 

This can be added as a required property on both Devices and HostAgents because I have gone through all the integrations to make sure that all of them were providing that property. 